### PR TITLE
Configuration extensions for RedisServiceConnectorFactory creation

### DIFF
--- a/src/Steeltoe.CloudFoundry.Connector.Redis/RedisCacheConfigurationExtensions.cs
+++ b/src/Steeltoe.CloudFoundry.Connector.Redis/RedisCacheConfigurationExtensions.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+using Steeltoe.CloudFoundry.Connector.Services;
+
+namespace Steeltoe.CloudFoundry.Connector.Redis
+{
+    public static class RedisCacheConfigurationExtensions
+    {
+        public static RedisServiceConnectorFactory CreateRedisServiceConnectorFactory(this IConfiguration config, string serviceName = null)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException(nameof(config));
+            }
+
+            var redisConfig = new RedisCacheConnectorOptions(config);
+            return config.CreateRedisServiceConnectorFactory(config, serviceName);
+        }
+
+        public static RedisServiceConnectorFactory CreateRedisServiceConnectorFactory(this IConfiguration config, IConfiguration connectorConfiguration, string serviceName = null)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException(nameof(config));
+            }
+
+            if (connectorConfiguration == null)
+            {
+                throw new ArgumentNullException(nameof(connectorConfiguration));
+            }
+
+            var connectorOptions = new RedisCacheConnectorOptions(connectorConfiguration);
+            return config.CreateRedisServiceConnectorFactory(connectorOptions, serviceName);
+        }
+
+        public static RedisServiceConnectorFactory CreateRedisServiceConnectorFactory(this IConfiguration config, RedisCacheConnectorOptions connectorOptions, string serviceName = null)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException(nameof(config));
+            }
+
+            if (connectorOptions == null)
+            {
+                throw new ArgumentNullException(nameof(connectorOptions));
+            }
+
+            var info = serviceName == null ? config.GetSingletonServiceInfo<RedisServiceInfo>() : config.GetRequiredServiceInfo<RedisServiceInfo>(serviceName);
+            return new RedisServiceConnectorFactory(info, connectorOptions);
+        }
+    }
+}

--- a/src/Steeltoe.CloudFoundry.Connector.Redis/RedisCacheServiceCollectionExtensions.cs
+++ b/src/Steeltoe.CloudFoundry.Connector.Redis/RedisCacheServiceCollectionExtensions.cs
@@ -14,20 +14,17 @@
 // limitations under the License.
 //
 
-
+using System;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Steeltoe.CloudFoundry.Connector.Services;
-using System;
 using StackExchange.Redis;
 
 namespace Steeltoe.CloudFoundry.Connector.Redis
 {
     public static class RedisCacheServiceCollectionExtensions
     {
-    
         public static IServiceCollection AddDistributedRedisCache(this IServiceCollection services, IConfiguration config, ILoggerFactory logFactory = null)
         {
             if (services == null)
@@ -40,11 +37,7 @@ namespace Steeltoe.CloudFoundry.Connector.Redis
                 throw new ArgumentNullException(nameof(config));
             }
 
-            RedisCacheConnectorOptions redisConfig = new RedisCacheConnectorOptions(config);
-            RedisServiceInfo info = config.GetSingletonServiceInfo<RedisServiceInfo>();
-            RedisServiceConnectorFactory factory = new RedisServiceConnectorFactory(info, redisConfig); ;
-            services.AddSingleton(typeof(IDistributedCache), factory.CreateCache);
-            return services;
+            return services.AddDistributedRedisCache(config, config, null);
         }
 
         public static IServiceCollection AddDistributedRedisCache(this IServiceCollection services, IConfiguration config, string serviceName, ILoggerFactory logFactory = null)
@@ -64,12 +57,26 @@ namespace Steeltoe.CloudFoundry.Connector.Redis
                 throw new ArgumentNullException(nameof(config));
             }
 
-            RedisCacheConnectorOptions redisConfig = new RedisCacheConnectorOptions(config);
-            RedisServiceInfo info = config.GetRequiredServiceInfo<RedisServiceInfo>(serviceName);
-            RedisServiceConnectorFactory factory = new RedisServiceConnectorFactory(info, redisConfig);
+            return services.AddDistributedRedisCache(config, config, serviceName);
+        }
+
+        public static IServiceCollection AddDistributedRedisCache(this IServiceCollection services, IConfiguration applicationConfiguration, IConfiguration connectorConfiguration, string serviceName)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (applicationConfiguration == null)
+            {
+                throw new ArgumentNullException(nameof(applicationConfiguration));
+            }
+
+            var factory = applicationConfiguration.CreateRedisServiceConnectorFactory(connectorConfiguration ?? applicationConfiguration, serviceName);
             services.AddSingleton(typeof(IDistributedCache), factory.CreateCache);
             return services;
         }
+
         public static IServiceCollection AddRedisConnectionMultiplexer(this IServiceCollection services, IConfiguration config)
         {
             if (services == null)
@@ -82,11 +89,7 @@ namespace Steeltoe.CloudFoundry.Connector.Redis
                 throw new ArgumentNullException(nameof(config));
             }
 
-            RedisCacheConnectorOptions redisConfig = new RedisCacheConnectorOptions(config);
-            RedisServiceInfo info = config.GetSingletonServiceInfo<RedisServiceInfo>();
-            RedisServiceConnectorFactory factory = new RedisServiceConnectorFactory(info, redisConfig); ;
-            services.AddSingleton(typeof(IConnectionMultiplexer), factory.CreateConnection);
-            return services;
+            return services.AddRedisConnectionMultiplexer(config, config, null);
         }
 
         public static IServiceCollection AddRedisConnectionMultiplexer(this IServiceCollection services, IConfiguration config, string serviceName)
@@ -106,12 +109,24 @@ namespace Steeltoe.CloudFoundry.Connector.Redis
                 throw new ArgumentNullException(nameof(config));
             }
 
-            RedisCacheConnectorOptions redisConfig = new RedisCacheConnectorOptions(config);
-            RedisServiceInfo info = config.GetRequiredServiceInfo<RedisServiceInfo>(serviceName);
-            RedisServiceConnectorFactory factory = new RedisServiceConnectorFactory(info, redisConfig);
+            return services.AddRedisConnectionMultiplexer(config, config, serviceName);
+        }
+
+        public static IServiceCollection AddRedisConnectionMultiplexer(this IServiceCollection services, IConfiguration applicationConfiguration, IConfiguration connectorConfiguration, string serviceName)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (applicationConfiguration == null)
+            {
+                throw new ArgumentNullException(nameof(applicationConfiguration));
+            }
+
+            var factory = applicationConfiguration.CreateRedisServiceConnectorFactory(connectorConfiguration ?? applicationConfiguration, serviceName);
             services.AddSingleton(typeof(IConnectionMultiplexer), factory.CreateConnection);
             return services;
         }
-
     }
 }

--- a/test/Steeltoe.CloudFoundry.Connector.Redis.Test/RedisCacheConfigurationExtensionsTest.cs
+++ b/test/Steeltoe.CloudFoundry.Connector.Redis.Test/RedisCacheConfigurationExtensionsTest.cs
@@ -1,0 +1,216 @@
+﻿//
+// Copyright 2015 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using StackExchange.Redis;
+using Steeltoe.Extensions.Configuration;
+using System;
+using System.IO;
+using Xunit;
+
+namespace Steeltoe.CloudFoundry.Connector.Redis.Test
+{
+    public class RedisCacheConfigurationExtensionsTest
+    {
+        public RedisCacheConfigurationExtensionsTest()
+        {
+            Environment.SetEnvironmentVariable("VCAP_APPLICATION", null);
+            Environment.SetEnvironmentVariable("VCAP_SERVICES", null);
+        }
+
+        [Fact]
+        public void CreateRedisServiceConnectorFactory_ThrowsIfConfigurationNull()
+        {
+            // Arrange
+            IConfigurationRoot config = null;
+            IConfigurationRoot connectorConfiguration = new ConfigurationBuilder().Build();
+            RedisCacheConnectorOptions connectorOptions = new RedisCacheConnectorOptions();
+
+            // Act and Assert
+            var ex = Assert.Throws<ArgumentNullException>(() => RedisCacheConfigurationExtensions.CreateRedisServiceConnectorFactory(config, "foobar"));
+            Assert.Contains(nameof(config), ex.Message);
+
+            var ex2 = Assert.Throws<ArgumentNullException>(() => RedisCacheConfigurationExtensions.CreateRedisServiceConnectorFactory(config, connectorConfiguration, "foobar"));
+            Assert.Contains(nameof(config), ex2.Message);
+
+            var ex3 = Assert.Throws<ArgumentNullException>(() => RedisCacheConfigurationExtensions.CreateRedisServiceConnectorFactory(config, connectorOptions, "foobar"));
+            Assert.Contains(nameof(config), ex3.Message);
+        }
+
+        [Fact]
+        public void CreateRedisServiceConnectorFactory_ThrowsIfConnectorConfigurationNull()
+        {
+            // Arrange
+            IConfigurationRoot config = new ConfigurationBuilder().Build();
+            IConfigurationRoot connectorConfiguration = null;
+
+            // Act and Assert
+            var ex = Assert.Throws<ArgumentNullException>(() => RedisCacheConfigurationExtensions.CreateRedisServiceConnectorFactory(config, connectorConfiguration, "foobar"));
+            Assert.Contains(nameof(connectorConfiguration), ex.Message);
+        }
+
+        [Fact]
+        public void CreateRedisServiceConnectorFactory_ThrowsIfConnectorOptionsNull()
+        {
+            // Arrange
+            IConfigurationRoot config = new ConfigurationBuilder().Build();
+            RedisCacheConnectorOptions connectorOptions = null;
+
+            // Act and Assert
+            var ex = Assert.Throws<ArgumentNullException>(() => RedisCacheConfigurationExtensions.CreateRedisServiceConnectorFactory(config, connectorOptions, "foobar"));
+            Assert.Contains(nameof(connectorOptions), ex.Message);
+        }
+
+        [Fact]
+        public void CreateRedisServiceConnectorFactory_WithServiceName_NoVCAPs_ThrowsConnectorException()
+        {
+            // Arrange
+            IServiceCollection services = new ServiceCollection();
+            IConfigurationRoot config = new ConfigurationBuilder().Build();
+            RedisCacheConnectorOptions connectorOptions = new RedisCacheConnectorOptions();
+
+            // Act and Assert
+            var ex = Assert.Throws<ConnectorException>(() => RedisCacheConfigurationExtensions.CreateRedisServiceConnectorFactory(config, "foobar"));
+            Assert.Contains("foobar", ex.Message);
+
+            var ex2 = Assert.Throws<ConnectorException>(() => RedisCacheConfigurationExtensions.CreateRedisServiceConnectorFactory(config, config, "foobar"));
+            Assert.Contains("foobar", ex2.Message);
+
+            var ex3 = Assert.Throws<ConnectorException>(() => RedisCacheConfigurationExtensions.CreateRedisServiceConnectorFactory(config, connectorOptions, "foobar"));
+            Assert.Contains("foobar", ex3.Message);
+        }
+
+        [Fact]
+        public void CreateRedisServiceConnectorFactory_NoVCAPs_CreatesFactory()
+        {
+            // Arrange
+            var appsettings = @"
+{
+   'redis': {
+        'client': {
+            'host': '127.0.0.1',
+            'port': 1234,
+            'password': 'password',
+            'abortOnConnectFail': false
+        }
+   }
+}";
+            var path = TestHelpers.CreateTempFile(appsettings);
+            string directory = Path.GetDirectoryName(path);
+            string fileName = Path.GetFileName(path);
+
+            ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.SetBasePath(directory);
+            configurationBuilder.AddJsonFile(fileName);
+            var config = configurationBuilder.Build();
+            var connectorOptions = new RedisCacheConnectorOptions(config);
+
+            // Act and Assert
+            Assert.NotNull(RedisCacheConfigurationExtensions.CreateRedisServiceConnectorFactory(config));
+            Assert.NotNull(RedisCacheConfigurationExtensions.CreateRedisServiceConnectorFactory(new ConfigurationBuilder().Build(), config));
+            Assert.NotNull(RedisCacheConfigurationExtensions.CreateRedisServiceConnectorFactory(new ConfigurationBuilder().Build(), connectorOptions));
+        }
+
+        [Fact]
+        public void CreateRedisServiceConnectorFactory_MultipleRedisServices_ThrowsConnectorException()
+        {
+            // Arrange
+            var env1 = @"
+{
+      'limits': {
+        'fds': 16384,
+        'mem': 1024,
+        'disk': 1024
+      },
+      'application_name': 'spring-cloud-broker',
+      'application_uris': [
+        'spring-cloud-broker.apps.testcloud.com'
+      ],
+      'name': 'spring-cloud-broker',
+      'space_name': 'p-spring-cloud-services',
+      'space_id': '65b73473-94cc-4640-b462-7ad52838b4ae',
+      'uris': [
+        'spring-cloud-broker.apps.testcloud.com'
+      ],
+      'users': null,
+      'version': '07e112f7-2f71-4f5a-8a34-db51dbed30a3',
+      'application_version': '07e112f7-2f71-4f5a-8a34-db51dbed30a3',
+      'application_id': '798c2495-fe75-49b1-88da-b81197f2bf06'
+    }
+}";
+            var env2 = @"
+{
+      'p-redis': [
+        {
+            'credentials': {
+                'host': '192.168.0.103',
+                'password': '133de7c8-9f3a-4df1-8a10-676ba7ddaa10',
+                'port': 60287
+            },
+          'syslog_drain_url': null,
+          'label': 'p-redis',
+          'provider': null,
+          'plan': 'shared-vm',
+          'name': 'myRedisService1',
+          'tags': [
+            'pivotal',
+            'redis'
+          ]
+        }, 
+        {
+            'credentials': {
+                'host': '192.168.0.103',
+                'password': '133de7c8-9f3a-4df1-8a10-676ba7ddaa10',
+                'port': 60287
+            },
+          'syslog_drain_url': null,
+          'label': 'p-redis',
+          'provider': null,
+          'plan': 'shared-vm',
+          'name': 'myRedisService2',
+          'tags': [
+            'pivotal',
+            'redis'
+          ]
+        } 
+      ]
+}
+";
+            // Arrange
+            IServiceCollection services = new ServiceCollection();
+
+            Environment.SetEnvironmentVariable("VCAP_APPLICATION", env1);
+            Environment.SetEnvironmentVariable("VCAP_SERVICES", env2);
+
+            ConfigurationBuilder builder = new ConfigurationBuilder();
+            builder.AddCloudFoundry();
+            var config = builder.Build();
+            RedisCacheConnectorOptions connectorOptions = new RedisCacheConnectorOptions();
+
+            // Act and Assert
+            var ex = Assert.Throws<ConnectorException>(() => RedisCacheConfigurationExtensions.CreateRedisServiceConnectorFactory(config));
+            Assert.Contains("Multiple", ex.Message);
+
+            var ex2 = Assert.Throws<ConnectorException>(() => RedisCacheConfigurationExtensions.CreateRedisServiceConnectorFactory(config, config));
+            Assert.Contains("Multiple", ex2.Message);
+
+            var ex3 = Assert.Throws<ConnectorException>(() => RedisCacheConfigurationExtensions.CreateRedisServiceConnectorFactory(config, connectorOptions));
+            Assert.Contains("Multiple", ex3.Message);
+        }
+    }
+}

--- a/test/Steeltoe.CloudFoundry.Connector.Redis.Test/RedisCacheServiceCollectionExtensionsTest.cs
+++ b/test/Steeltoe.CloudFoundry.Connector.Redis.Test/RedisCacheServiceCollectionExtensionsTest.cs
@@ -38,7 +38,7 @@ namespace Steeltoe.CloudFoundry.Connector.Redis.Test
         {
             // Arrange
             IServiceCollection services = null;
-            IConfigurationRoot config = null;
+            IConfigurationRoot config = new ConfigurationBuilder().Build();
 
             // Act and Assert
             var ex = Assert.Throws<ArgumentNullException>(() => RedisCacheServiceCollectionExtensions.AddDistributedRedisCache(services, config));
@@ -47,13 +47,17 @@ namespace Steeltoe.CloudFoundry.Connector.Redis.Test
             var ex2 = Assert.Throws<ArgumentNullException>(() => RedisCacheServiceCollectionExtensions.AddDistributedRedisCache(services, config, "foobar"));
             Assert.Contains(nameof(services), ex2.Message);
 
+            var ex3 = Assert.Throws<ArgumentNullException>(() => RedisCacheServiceCollectionExtensions.AddDistributedRedisCache(services, config, config, "foobar"));
+            Assert.Contains(nameof(services), ex3.Message);
         }
+
         [Fact]
-        public void AddDistributedRedisCache_ThrowsIfConfigurtionNull()
+        public void AddDistributedRedisCache_ThrowsIfConfigurationNull()
         {
             // Arrange
             IServiceCollection services = new ServiceCollection();
             IConfigurationRoot config = null;
+            IConfigurationRoot connectionConfig = new ConfigurationBuilder().Build();
 
             // Act and Assert
             var ex = Assert.Throws<ArgumentNullException>(() => RedisCacheServiceCollectionExtensions.AddDistributedRedisCache(services, config));
@@ -62,6 +66,8 @@ namespace Steeltoe.CloudFoundry.Connector.Redis.Test
             var ex2 = Assert.Throws<ArgumentNullException>(() => RedisCacheServiceCollectionExtensions.AddDistributedRedisCache(services, config, "foobar"));
             Assert.Contains(nameof(config), ex2.Message);
 
+            var ex3 = Assert.Throws<ArgumentNullException>(() => RedisCacheServiceCollectionExtensions.AddDistributedRedisCache(services, config, connectionConfig, "foobar"));
+            Assert.Contains("applicationConfiguration", ex3.Message);
         }
 
         [Fact]
@@ -69,7 +75,7 @@ namespace Steeltoe.CloudFoundry.Connector.Redis.Test
         {
             // Arrange
             IServiceCollection services = new ServiceCollection();
-            IConfigurationRoot config = null;
+            IConfigurationRoot config = new ConfigurationBuilder().Build();
             string serviceName = null;
 
             // Act and Assert
@@ -104,6 +110,8 @@ namespace Steeltoe.CloudFoundry.Connector.Redis.Test
             var ex = Assert.Throws<ConnectorException>(() => RedisCacheServiceCollectionExtensions.AddDistributedRedisCache(services, config, "foobar"));
             Assert.Contains("foobar", ex.Message);
 
+            var ex2 = Assert.Throws<ConnectorException>(() => RedisCacheServiceCollectionExtensions.AddDistributedRedisCache(services, config, config, "foobar"));
+            Assert.Contains("foobar", ex2.Message);
         }
 
         [Fact]
@@ -185,6 +193,8 @@ namespace Steeltoe.CloudFoundry.Connector.Redis.Test
             var ex = Assert.Throws<ConnectorException>(() => RedisCacheServiceCollectionExtensions.AddDistributedRedisCache(services, config));
             Assert.Contains("Multiple", ex.Message);
 
+            var ex2 = Assert.Throws<ConnectorException>(() => RedisCacheServiceCollectionExtensions.AddDistributedRedisCache(services, config, config, null));
+            Assert.Contains("Multiple", ex2.Message);
         }
 
         [Fact]
@@ -192,7 +202,7 @@ namespace Steeltoe.CloudFoundry.Connector.Redis.Test
         {
             // Arrange
             IServiceCollection services = null;
-            IConfigurationRoot config = null;
+            IConfigurationRoot config = new ConfigurationBuilder().Build();
 
             // Act and Assert
             var ex = Assert.Throws<ArgumentNullException>(() => RedisCacheServiceCollectionExtensions.AddRedisConnectionMultiplexer(services, config));
@@ -201,13 +211,17 @@ namespace Steeltoe.CloudFoundry.Connector.Redis.Test
             var ex2 = Assert.Throws<ArgumentNullException>(() => RedisCacheServiceCollectionExtensions.AddRedisConnectionMultiplexer(services, config, "foobar"));
             Assert.Contains(nameof(services), ex2.Message);
 
+            var ex3 = Assert.Throws<ArgumentNullException>(() => RedisCacheServiceCollectionExtensions.AddRedisConnectionMultiplexer(services, config, config, "foobar"));
+            Assert.Contains(nameof(services), ex3.Message);
         }
+
         [Fact]
-        public void AddRedisConnectionMultiplexer_ThrowsIfConfigurtionNull()
+        public void AddRedisConnectionMultiplexer_ThrowsIfConfigurationNull()
         {
             // Arrange
             IServiceCollection services = new ServiceCollection();
             IConfigurationRoot config = null;
+            IConfigurationRoot connectionConfig = new ConfigurationBuilder().Build();
 
             // Act and Assert
             var ex = Assert.Throws<ArgumentNullException>(() => RedisCacheServiceCollectionExtensions.AddRedisConnectionMultiplexer(services, config));
@@ -216,6 +230,8 @@ namespace Steeltoe.CloudFoundry.Connector.Redis.Test
             var ex2 = Assert.Throws<ArgumentNullException>(() => RedisCacheServiceCollectionExtensions.AddRedisConnectionMultiplexer(services, config, "foobar"));
             Assert.Contains(nameof(config), ex2.Message);
 
+            var ex3 = Assert.Throws<ArgumentNullException>(() => RedisCacheServiceCollectionExtensions.AddRedisConnectionMultiplexer(services, config, connectionConfig, "foobar"));
+            Assert.Contains("applicationConfiguration", ex3.Message);
         }
 
         [Fact]
@@ -256,14 +272,16 @@ namespace Steeltoe.CloudFoundry.Connector.Redis.Test
             configurationBuilder.AddJsonFile(fileName);
             var config = configurationBuilder.Build();
 
-            IServiceCollection services = new ServiceCollection();
-
             // Act and Assert
+            IServiceCollection services = new ServiceCollection();
             RedisCacheServiceCollectionExtensions.AddRedisConnectionMultiplexer(services, config);
-
             var service = services.BuildServiceProvider().GetService<IConnectionMultiplexer>();
             Assert.NotNull(service);
 
+            IServiceCollection services2 = new ServiceCollection();
+            RedisCacheServiceCollectionExtensions.AddRedisConnectionMultiplexer(services2, config, config, null);
+            var service2 = services2.BuildServiceProvider().GetService<IConnectionMultiplexer>();
+            Assert.NotNull(service2);
         }
 
         [Fact]
@@ -277,7 +295,8 @@ namespace Steeltoe.CloudFoundry.Connector.Redis.Test
             var ex = Assert.Throws<ConnectorException>(() => RedisCacheServiceCollectionExtensions.AddRedisConnectionMultiplexer(services, config, "foobar"));
             Assert.Contains("foobar", ex.Message);
 
+            var ex2 = Assert.Throws<ConnectorException>(() => RedisCacheServiceCollectionExtensions.AddRedisConnectionMultiplexer(services, config, config, "foobar"));
+            Assert.Contains("foobar", ex2.Message);
         }
-
     }
 }


### PR DESCRIPTION
Resolves #9.

- Added new `IConfiguration` extensions for creating a `RedisServiceConnectorFactory` that can be used outside of service registration.
- Added support for splitting application configuration from Redis connector configuration. This means you don't have to store your `redis` node at the root of your app config anymore - you can pass in a child node with the connector config or you can generate the `RedisCacheConnectorOptions` yourself.