### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ While the primary usage of the connectors is intended to be with ASP.NET Core ap
 Depending on their level of support, the connectors and samples have been tested  on .NET Core 1.1, .NET 4.5.1/4.6.x, and on ASP.NET Core 1.1.0.
 
 # Usage
-For more information on how to use these components see the online [Steeltoe documentation](http://steeltoe.io/).
+For more information on how to use these components see the online [Steeltoe documentation](https://steeltoe.io/).
 
 # Nuget Feeds
 All new connector development is done on the dev branch. More stable versions of the connectors can be found on the master branch. The latest prebuilt packages from each branch can be found on one of two MyGet feeds. Released version can be found on nuget.org.

--- a/open_source_licenses.txt
+++ b/open_source_licenses.txt
@@ -256,11 +256,11 @@ SOFTWARE.
 
 Third Party Licenses:
 
-The Redis project (http://redis.io/) is independent of this client library, and
+The Redis project (https://redis.io/) is independent of this client library, and
 is licensed separately under the three clause BSD license. The full license
-information can be viewed here: http://redis.io/topics/license
+information can be viewed here: https://redis.io/topics/license
 
-This tool makes use of the "redis-doc" library from http://redis.io/documentation
+This tool makes use of the "redis-doc" library from https://redis.io/documentation
 in the intellisense comments, which is licensed under the
 Creative Commons Attribution-ShareAlike 4.0 International license; full
 details are available here:
@@ -592,7 +592,7 @@ Apache License, V2.0 is applicable to the following component(s).
 
 Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.
 Microsoft Open Technologies would like to thank its contributors, a list of whom
-are at http://aspnetwebstack.codeplex.com/wikipage?title=Contributors.
+are at https://aspnetwebstack.codeplex.com/wikipage?title=Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you
 may not use this file except in compliance with the License. You may
@@ -1437,19 +1437,19 @@ END OF TERMS AND CONDITIONS
 Creative Commons Attribution-ShareAlike 4.0 International 
 
 Official translations of this license are available in other languages.
-Creative Commons Corporation (“Creative Commons”) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an “as-is” basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.
+Creative Commons Corporation (ï¿½Creative Commonsï¿½) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an ï¿½as-isï¿½ basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.
 
 Using Creative Commons Public Licenses
 
 Creative Commons public licenses provide a standard set of terms and conditions that creators and other rights holders may use to share original works of authorship and other material subject to copyright and certain other rights specified in the public license below. The following considerations are for informational purposes only, are not exhaustive, and do not form part of our licenses.
 
 Considerations for licensors: Our public licenses are intended for use by those authorized to give the public permission to use material in ways otherwise restricted by copyright and certain other rights. Our licenses are irrevocable. Licensors should read and understand the terms and conditions of the license they choose before applying it. Licensors should also secure all rights necessary before applying our licenses so that the public can reuse the material as expected. Licensors should clearly mark any material not subject to the license. This includes other CC-licensed material, or material used under an exception or limitation to copyright. More considerations for licensors.
-Considerations for the public: By using one of our public licenses, a licensor grants the public permission to use the licensed material under specified terms and conditions. If the licensor’s permission is not necessary for any reason–for example, because of any applicable exception or limitation to copyright–then that use is not regulated by the license. Our licenses grant only permissions under copyright and certain other rights that a licensor has authority to grant. Use of the licensed material may still be restricted for other reasons, including because others have copyright or other rights in the material. A licensor may make special requests, such as asking that all changes be marked or described. Although not required by our licenses, you are encouraged to respect those requests where reasonable. More considerations for the public.
+Considerations for the public: By using one of our public licenses, a licensor grants the public permission to use the licensed material under specified terms and conditions. If the licensorï¿½s permission is not necessary for any reasonï¿½for example, because of any applicable exception or limitation to copyrightï¿½then that use is not regulated by the license. Our licenses grant only permissions under copyright and certain other rights that a licensor has authority to grant. Use of the licensed material may still be restricted for other reasons, including because others have copyright or other rights in the material. A licensor may make special requests, such as asking that all changes be marked or described. Although not required by our licenses, you are encouraged to respect those requests where reasonable. More considerations for the public.
 Creative Commons Attribution-ShareAlike 4.0 International Public License
 
 By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution-ShareAlike 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
 
-Section 1 – Definitions.
+Section 1 ï¿½ Definitions.
 
 Adapted Material means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
 Adapter's License means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.
@@ -1464,7 +1464,7 @@ Licensor means the individual(s) or entity(ies) granting rights under this Publi
 Share means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
 Sui Generis Database Rights means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
 You means the individual or entity exercising the Licensed Rights under this Public License. Your has a corresponding meaning.
-Section 2 – Scope.
+Section 2 ï¿½ Scope.
 
 License grant.
 Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to:
@@ -1474,8 +1474,8 @@ Exceptions and Limitations. For the avoidance of doubt, where Exceptions and Lim
 Term. The term of this Public License is specified in Section 6(a).
 Media and formats; technical modifications allowed. The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a)(4) never produces Adapted Material.
 Downstream recipients.
-Offer from the Licensor – Licensed Material. Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
-Additional offer from the Licensor – Adapted Material. Every recipient of Adapted Material from You automatically receives an offer from the Licensor to exercise the Licensed Rights in the Adapted Material under the conditions of the Adapter’s License You apply.
+Offer from the Licensor ï¿½ Licensed Material. Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
+Additional offer from the Licensor ï¿½ Adapted Material. Every recipient of Adapted Material from You automatically receives an offer from the Licensor to exercise the Licensed Rights in the Adapted Material under the conditions of the Adapterï¿½s License You apply.
 No downstream restrictions. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
 No endorsement. Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i).
 Other rights.
@@ -1483,7 +1483,7 @@ Other rights.
 Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
 Patent and trademark rights are not licensed under this Public License.
 To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties.
-Section 3 – License Conditions.
+Section 3 ï¿½ License Conditions.
 
 Your exercise of the Licensed Rights is expressly made subject to the following conditions.
 
@@ -1504,10 +1504,10 @@ If requested by the Licensor, You must remove any of the information required by
 ShareAlike.
 In addition to the conditions in Section 3(a), if You Share Adapted Material You produce, the following conditions also apply.
 
-The Adapter’s License You apply must be a Creative Commons license with the same License Elements, this version or later, or a BY-SA Compatible License.
+The Adapterï¿½s License You apply must be a Creative Commons license with the same License Elements, this version or later, or a BY-SA Compatible License.
 You must include the text of, or the URI or hyperlink to, the Adapter's License You apply. You may satisfy this condition in any reasonable manner based on the medium, means, and context in which You Share Adapted Material.
 You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, Adapted Material that restrict exercise of the rights granted under the Adapter's License You apply.
-Section 4 – Sui Generis Database Rights.
+Section 4 ï¿½ Sui Generis Database Rights.
 
 Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
 
@@ -1515,12 +1515,12 @@ for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reu
 if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material, including for purposes of Section 3(b); and
 You must comply with the conditions in Section 3(a) if You Share all or a substantial portion of the contents of the database.
 For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
-Section 5 – Disclaimer of Warranties and Limitation of Liability.
+Section 5 ï¿½ Disclaimer of Warranties and Limitation of Liability.
 
 Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.
 To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.
 The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
-Section 6 – Term and Termination.
+Section 6 ï¿½ Term and Termination.
 
 This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
 Where Your right to use the Licensed Material has terminated under Section 6(a), it reinstates:
@@ -1530,17 +1530,17 @@ upon express reinstatement by the Licensor.
 For the avoidance of doubt, this Section 6(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
 For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
 Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
-Section 7 – Other Terms and Conditions.
+Section 7 ï¿½ Other Terms and Conditions.
 
 The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
 Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
-Section 8 – Interpretation.
+Section 8 ï¿½ Interpretation.
 
 For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
 To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
 No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
 Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
-Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to apply one of its public licenses to material it publishes and in those instances will be considered the “Licensor.” The text of the Creative Commons public licenses is dedicated to the public domain under the CC0 Public Domain Dedication. Except for the limited purpose of indicating that material is shared under a Creative Commons public license or as otherwise permitted by the Creative Commons policies published at creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative Commons” or any other trademark or logo of Creative Commons without its prior written consent including, without limitation, in connection with any unauthorized modifications to any of its public licenses or any other arrangements, understandings, or agreements concerning use of licensed material. For the avoidance of doubt, this paragraph does not form part of the public licenses.
+Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to apply one of its public licenses to material it publishes and in those instances will be considered the ï¿½Licensor.ï¿½ The text of the Creative Commons public licenses is dedicated to the public domain under the CC0 Public Domain Dedication. Except for the limited purpose of indicating that material is shared under a Creative Commons public license or as otherwise permitted by the Creative Commons policies published at creativecommons.org/policies, Creative Commons does not authorize the use of the trademark ï¿½Creative Commonsï¿½ or any other trademark or logo of Creative Commons without its prior written consent including, without limitation, in connection with any unauthorized modifications to any of its public licenses or any other arrangements, understandings, or agreements concerning use of licensed material. For the avoidance of doubt, this paragraph does not form part of the public licenses.
 
 Creative Commons may be contacted at creativecommons.org.
 
@@ -1555,7 +1555,7 @@ available (as would be noted above), you may obtain a copy of
 the source code corresponding to the binaries for such open
 source components and modifications thereto, if any, (the
 "Source Files"), by downloading the Source Files from Pivotal's website at
-http://network.pivotal.io/open-source, or by sending a request, 
+https://network.pivotal.io/open-source, or by sending a request, 
 with your name and address to: Pivotal Software, Inc., 875 Howard Street, 5th
 floor, San Francisco, CA 94103, Attention: General Counsel. All such requests
 should clearly specify: OPEN SOURCE FILES REQUEST, Attention General Counsel. 

--- a/src/Steeltoe.CloudFoundry.Connector.Hystrix/README.md
+++ b/src/Steeltoe.CloudFoundry.Connector.Hystrix/README.md
@@ -2,4 +2,4 @@
 
 This project contains a Steeltoe Connector for Hystrix Dashboard.
 
-For more information on how to use this component see the online [Steeltoe documentation](http://steeltoe.io/).
+For more information on how to use this component see the online [Steeltoe documentation](https://steeltoe.io/).

--- a/src/Steeltoe.CloudFoundry.Connector.Hystrix/Steeltoe.CloudFoundry.Connector.Hystrix.csproj
+++ b/src/Steeltoe.CloudFoundry.Connector.Hystrix/Steeltoe.CloudFoundry.Connector.Hystrix.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>Steeltoe.CloudFoundry.Connector.Hystrix</AssemblyName>
     <PackageId>Steeltoe.CloudFoundry.Connector.Hystrix</PackageId>
     <PackageTags>CloudFoundry;ASPNET Core;Connectors;Hystrix;Dashboard</PackageTags>
-    <PackageIconUrl>http://steeltoe.io/images/transparent.png</PackageIconUrl>
-    <PackageProjectUrl>http://steeltoe.io</PackageProjectUrl>
+    <PackageIconUrl>https://steeltoe.io/images/transparent.png</PackageIconUrl>
+    <PackageProjectUrl>https://steeltoe.io</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
   </PropertyGroup>
 

--- a/src/Steeltoe.CloudFoundry.Connector.MySql/README.md
+++ b/src/Steeltoe.CloudFoundry.Connector.MySql/README.md
@@ -2,4 +2,4 @@
 
 This project contains a Steeltoe Connector for MySql.  This connector simplifies using [Connector/NET - 6.9.9/7.0.x](https://dev.mysql.com/downloads/connector/net/) in an application running on CloudFoundry.
 
-For more information on how to use this component see the online [Steeltoe documentation](http://steeltoe.io/).
+For more information on how to use this component see the online [Steeltoe documentation](https://steeltoe.io/).

--- a/src/Steeltoe.CloudFoundry.Connector.MySql/Steeltoe.CloudFoundry.Connector.MySql.csproj
+++ b/src/Steeltoe.CloudFoundry.Connector.MySql/Steeltoe.CloudFoundry.Connector.MySql.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>Steeltoe.CloudFoundry.Connector.MySql</AssemblyName>
     <PackageId>Steeltoe.CloudFoundry.Connector.MySql</PackageId>
     <PackageTags>CloudFoundry;ASPNET Core;Connectors;MySql</PackageTags>
-    <PackageIconUrl>http://steeltoe.io/images/transparent.png</PackageIconUrl>
-    <PackageProjectUrl>http://steeltoe.io</PackageProjectUrl>
+    <PackageIconUrl>https://steeltoe.io/images/transparent.png</PackageIconUrl>
+    <PackageProjectUrl>https://steeltoe.io</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
   </PropertyGroup>
 

--- a/src/Steeltoe.CloudFoundry.Connector.OAuth/README.md
+++ b/src/Steeltoe.CloudFoundry.Connector.OAuth/README.md
@@ -4,4 +4,4 @@ This project contains a Steeltoe Connector for OAuth services.  This connector s
 
 It exposes the OAuth service configuration data as injectable `IOption<OAuthServiceOptions>`. This connector is used by the ASP.NET Core [CloudFoundry External Security Provider](https://github.com/SteeltoeOSS/Security), but can be used standalone as well.
 
-For more information on how to use this component see the online [Steeltoe documentation](http://steeltoe.io/).
+For more information on how to use this component see the online [Steeltoe documentation](https://steeltoe.io/).

--- a/src/Steeltoe.CloudFoundry.Connector.OAuth/Steeltoe.CloudFoundry.Connector.OAuth.csproj
+++ b/src/Steeltoe.CloudFoundry.Connector.OAuth/Steeltoe.CloudFoundry.Connector.OAuth.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>Steeltoe.CloudFoundry.Connector.OAuth</AssemblyName>
     <PackageId>Steeltoe.CloudFoundry.Connector.OAuth</PackageId>
     <PackageTags>CloudFoundry;ASPNET Core;Connectors;OAuth2;SSO;Security</PackageTags>
-    <PackageIconUrl>http://steeltoe.io/images/transparent.png</PackageIconUrl>
-    <PackageProjectUrl>http://steeltoe.io</PackageProjectUrl>
+    <PackageIconUrl>https://steeltoe.io/images/transparent.png</PackageIconUrl>
+    <PackageProjectUrl>https://steeltoe.io</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
   </PropertyGroup>
 

--- a/src/Steeltoe.CloudFoundry.Connector.PostgreSql/README.md
+++ b/src/Steeltoe.CloudFoundry.Connector.PostgreSql/README.md
@@ -1,5 +1,5 @@
 ﻿# CloudFoundry .NET Postgres Connector
 
-This project contains a Steeltoe Connector for Postgres.  This connector simplifies using [Npgsql - 3.1.9](http://www.npgsql.org/) in an application running on CloudFoundry.
+This project contains a Steeltoe Connector for Postgres.  This connector simplifies using [Npgsql - 3.1.9](https://www.npgsql.org/) in an application running on CloudFoundry.
 
-For more information on how to use this component see the online [Steeltoe documentation](http://steeltoe.io/).
+For more information on how to use this component see the online [Steeltoe documentation](https://steeltoe.io/).

--- a/src/Steeltoe.CloudFoundry.Connector.PostgreSql/Steeltoe.CloudFoundry.Connector.PostgreSql.csproj
+++ b/src/Steeltoe.CloudFoundry.Connector.PostgreSql/Steeltoe.CloudFoundry.Connector.PostgreSql.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>Steeltoe.CloudFoundry.Connector.PostgreSql</AssemblyName>
     <PackageId>Steeltoe.CloudFoundry.Connector.PostgreSql</PackageId>
     <PackageTags>CloudFoundry;ASPNET Core;Connectors;Postgres</PackageTags>
-    <PackageIconUrl>http://steeltoe.io/images/transparent.png</PackageIconUrl>
-    <PackageProjectUrl>http://steeltoe.io</PackageProjectUrl>
+    <PackageIconUrl>https://steeltoe.io/images/transparent.png</PackageIconUrl>
+    <PackageProjectUrl>https://steeltoe.io</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
   </PropertyGroup>
 

--- a/src/Steeltoe.CloudFoundry.Connector.Rabbit/README.md
+++ b/src/Steeltoe.CloudFoundry.Connector.Rabbit/README.md
@@ -2,4 +2,4 @@
 
 This project contains a Steeltoe Connector for Rabbit.
 
-For more information on how to use this component see the online [Steeltoe documentation](http://steeltoe.io/).
+For more information on how to use this component see the online [Steeltoe documentation](https://steeltoe.io/).

--- a/src/Steeltoe.CloudFoundry.Connector.Rabbit/Steeltoe.CloudFoundry.Connector.Rabbit.csproj
+++ b/src/Steeltoe.CloudFoundry.Connector.Rabbit/Steeltoe.CloudFoundry.Connector.Rabbit.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>Steeltoe.CloudFoundry.Connector.Rabbit</AssemblyName>
     <PackageId>Steeltoe.CloudFoundry.Connector.Rabbit</PackageId>
     <PackageTags>CloudFoundry;ASPNET Core;Connectors;Rabbit</PackageTags>
-    <PackageIconUrl>http://steeltoe.io/images/transparent.png</PackageIconUrl>
-    <PackageProjectUrl>http://steeltoe.io</PackageProjectUrl>
+    <PackageIconUrl>https://steeltoe.io/images/transparent.png</PackageIconUrl>
+    <PackageProjectUrl>https://steeltoe.io</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
   </PropertyGroup>
 

--- a/src/Steeltoe.CloudFoundry.Connector.Redis/README.md
+++ b/src/Steeltoe.CloudFoundry.Connector.Redis/README.md
@@ -2,4 +2,4 @@
 
 This project contains a Steeltoe Connector for Redis.  This connector simplifies using Microsoft [RedisCache](https://github.com/aspnet/Caching/tree/dev/src/Microsoft.Extensions.Caching.Redis) and/or StackExchange [ConnectionMultiplexor](https://github.com/StackExchange/StackExchange.Redis) in an application running on CloudFoundry.
 
-For more information on how to use this component see the online [Steeltoe documentation](http://steeltoe.io/).
+For more information on how to use this component see the online [Steeltoe documentation](https://steeltoe.io/).

--- a/src/Steeltoe.CloudFoundry.Connector.Redis/Steeltoe.CloudFoundry.Connector.Redis.csproj
+++ b/src/Steeltoe.CloudFoundry.Connector.Redis/Steeltoe.CloudFoundry.Connector.Redis.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>Steeltoe.CloudFoundry.Connector.Redis</AssemblyName>
     <PackageId>Steeltoe.CloudFoundry.Connector.Redis</PackageId>
     <PackageTags>CloudFoundry;ASPNET Core;Connectors;Redis</PackageTags>
-    <PackageIconUrl>http://steeltoe.io/images/transparent.png</PackageIconUrl>
-    <PackageProjectUrl>http://steeltoe.io</PackageProjectUrl>
+    <PackageIconUrl>https://steeltoe.io/images/transparent.png</PackageIconUrl>
+    <PackageProjectUrl>https://steeltoe.io</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
   </PropertyGroup>
 

--- a/src/Steeltoe.CloudFoundry.Connector/Steeltoe.CloudFoundry.Connector.csproj
+++ b/src/Steeltoe.CloudFoundry.Connector/Steeltoe.CloudFoundry.Connector.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>Steeltoe.CloudFoundry.Connector</AssemblyName>
     <PackageId>Steeltoe.CloudFoundry.Connector</PackageId>
     <PackageTags>CloudFoundry;ASPNET Core;Connectors</PackageTags>
-    <PackageIconUrl>http://steeltoe.io/images/transparent.png</PackageIconUrl>
-    <PackageProjectUrl>http://steeltoe.io</PackageProjectUrl>
+    <PackageIconUrl>https://steeltoe.io/images/transparent.png</PackageIconUrl>
+    <PackageProjectUrl>https://steeltoe.io</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
   </PropertyGroup>
 

--- a/test/Steeltoe.CloudFoundry.Connector.Hystrix.Test/HystrixProviderServiceCollectionExtensionsTest.cs
+++ b/test/Steeltoe.CloudFoundry.Connector.Hystrix.Test/HystrixProviderServiceCollectionExtensionsTest.cs
@@ -182,9 +182,9 @@ namespace Steeltoe.CloudFoundry.Connector.Hystrix.Test
                   'username': 'a0f39f25-28a2-438e-a0e7-6c09d6d34dbd',
                   'port': 15672,
                   'host': '192.168.1.55',
-                  'uri': 'http://a0f39f25-28a2-438e-a0e7-6c09d6d34dbd:1clgf5ipeop36437dmr2em4duk@192.168.1.55:15672/api/',
+                  'uri': 'https://a0f39f25-28a2-438e-a0e7-6c09d6d34dbd:1clgf5ipeop36437dmr2em4duk@192.168.1.55:15672/api/',
                   'uris': [
-                    'http://a0f39f25-28a2-438e-a0e7-6c09d6d34dbd:1clgf5ipeop36437dmr2em4duk@192.168.1.55:15672/api/'
+                    'https://a0f39f25-28a2-438e-a0e7-6c09d6d34dbd:1clgf5ipeop36437dmr2em4duk@192.168.1.55:15672/api/'
                   ]
                 }
               },
@@ -250,9 +250,9 @@ namespace Steeltoe.CloudFoundry.Connector.Hystrix.Test
                   'username': 'a0f39f25-28a2-438e-a0e7-6c09d6d34dbd',
                   'port': 15672,
                   'host': '192.168.1.55',
-                  'uri': 'http://a0f39f25-28a2-438e-a0e7-6c09d6d34dbd:1clgf5ipeop36437dmr2em4duk@192.168.1.55:15672/api/',
+                  'uri': 'https://a0f39f25-28a2-438e-a0e7-6c09d6d34dbd:1clgf5ipeop36437dmr2em4duk@192.168.1.55:15672/api/',
                   'uris': [
-                    'http://a0f39f25-28a2-438e-a0e7-6c09d6d34dbd:1clgf5ipeop36437dmr2em4duk@192.168.1.55:15672/api/'
+                    'https://a0f39f25-28a2-438e-a0e7-6c09d6d34dbd:1clgf5ipeop36437dmr2em4duk@192.168.1.55:15672/api/'
                   ]
                 }
               },
@@ -368,9 +368,9 @@ namespace Steeltoe.CloudFoundry.Connector.Hystrix.Test
                   'username': 'a0f39f25-28a2-438e-a0e7-6c09d6d34dbd',
                   'port': 15672,
                   'host': '192.168.1.55',
-                  'uri': 'http://a0f39f25-28a2-438e-a0e7-6c09d6d34dbd:1clgf5ipeop36437dmr2em4duk@192.168.1.55:15672/api/',
+                  'uri': 'https://a0f39f25-28a2-438e-a0e7-6c09d6d34dbd:1clgf5ipeop36437dmr2em4duk@192.168.1.55:15672/api/',
                   'uris': [
-                    'http://a0f39f25-28a2-438e-a0e7-6c09d6d34dbd:1clgf5ipeop36437dmr2em4duk@192.168.1.55:15672/api/'
+                    'https://a0f39f25-28a2-438e-a0e7-6c09d6d34dbd:1clgf5ipeop36437dmr2em4duk@192.168.1.55:15672/api/'
                   ]
                 }
               },

--- a/test/Steeltoe.CloudFoundry.Connector.OAuth.Test/OAuthConfigurerTest.cs
+++ b/test/Steeltoe.CloudFoundry.Connector.OAuth.Test/OAuthConfigurerTest.cs
@@ -51,19 +51,19 @@ namespace Steeltoe.CloudFoundry.Connector.OAuth.Test
         public void Update_WithServiceInfo_UpdatesOAuthOptions_AsExpected()
         {
             OAuthServiceOptions opts = new OAuthServiceOptions();
-            SsoServiceInfo si = new SsoServiceInfo("myId", "myClientId", "myClientSecret", "http://foo.bar");
+            SsoServiceInfo si = new SsoServiceInfo("myId", "myClientId", "myClientSecret", "https://foo.bar");
      
             OAuthConfigurer configurer = new OAuthConfigurer();
             configurer.UpdateOptions(si, opts);
             
 
-            Assert.Equal("http://foo.bar" + OAuthConnectorDefaults.Default_AccessTokenUri, opts.AccessTokenUrl);
+            Assert.Equal("https://foo.bar" + OAuthConnectorDefaults.Default_AccessTokenUri, opts.AccessTokenUrl);
             Assert.Equal("myClientId", opts.ClientId);
             Assert.Equal("myClientSecret", opts.ClientSecret);
-            Assert.Equal("http://foo.bar" + OAuthConnectorDefaults.Default_JwtTokenKey, opts.JwtKeyUrl);
-            Assert.Equal("http://foo.bar" + OAuthConnectorDefaults.Default_CheckTokenUri, opts.TokenInfoUrl);
-            Assert.Equal("http://foo.bar" + OAuthConnectorDefaults.Default_AuthorizationUri, opts.UserAuthorizationUrl);
-            Assert.Equal("http://foo.bar" + OAuthConnectorDefaults.Default_UserInfoUri, opts.UserInfoUrl);
+            Assert.Equal("https://foo.bar" + OAuthConnectorDefaults.Default_JwtTokenKey, opts.JwtKeyUrl);
+            Assert.Equal("https://foo.bar" + OAuthConnectorDefaults.Default_CheckTokenUri, opts.TokenInfoUrl);
+            Assert.Equal("https://foo.bar" + OAuthConnectorDefaults.Default_AuthorizationUri, opts.UserAuthorizationUrl);
+            Assert.Equal("https://foo.bar" + OAuthConnectorDefaults.Default_UserInfoUri, opts.UserInfoUrl);
             Assert.True(opts.ValidateCertificates);
             Assert.NotNull(opts.Scope);
             Assert.Equal(0, opts.Scope.Count);
@@ -95,7 +95,7 @@ namespace Steeltoe.CloudFoundry.Connector.OAuth.Test
         [Fact]
         public void Configure_ServiceInfoOveridesConfig_ReturnsExpected()
         {
-            SsoServiceInfo si = new SsoServiceInfo("myId", "myClientId", "myClientSecret", "http://foo.bar");
+            SsoServiceInfo si = new SsoServiceInfo("myId", "myClientId", "myClientSecret", "https://foo.bar");
             OAuthConnectorOptions config = new OAuthConnectorOptions();
             OAuthConfigurer configurer = new OAuthConfigurer();
             var result = configurer.Configure(si, config);
@@ -105,13 +105,13 @@ namespace Steeltoe.CloudFoundry.Connector.OAuth.Test
             Assert.NotNull(opts);
 
 
-            Assert.Equal("http://foo.bar" + OAuthConnectorDefaults.Default_AccessTokenUri, opts.AccessTokenUrl);
+            Assert.Equal("https://foo.bar" + OAuthConnectorDefaults.Default_AccessTokenUri, opts.AccessTokenUrl);
             Assert.Equal("myClientId", opts.ClientId);
             Assert.Equal("myClientSecret", opts.ClientSecret);
-            Assert.Equal("http://foo.bar" + OAuthConnectorDefaults.Default_JwtTokenKey, opts.JwtKeyUrl);
-            Assert.Equal("http://foo.bar" + OAuthConnectorDefaults.Default_CheckTokenUri, opts.TokenInfoUrl);
-            Assert.Equal("http://foo.bar" + OAuthConnectorDefaults.Default_AuthorizationUri, opts.UserAuthorizationUrl);
-            Assert.Equal("http://foo.bar" + OAuthConnectorDefaults.Default_UserInfoUri, opts.UserInfoUrl);
+            Assert.Equal("https://foo.bar" + OAuthConnectorDefaults.Default_JwtTokenKey, opts.JwtKeyUrl);
+            Assert.Equal("https://foo.bar" + OAuthConnectorDefaults.Default_CheckTokenUri, opts.TokenInfoUrl);
+            Assert.Equal("https://foo.bar" + OAuthConnectorDefaults.Default_AuthorizationUri, opts.UserAuthorizationUrl);
+            Assert.Equal("https://foo.bar" + OAuthConnectorDefaults.Default_UserInfoUri, opts.UserInfoUrl);
             Assert.True(opts.ValidateCertificates);
             Assert.NotNull(opts.Scope);
             Assert.Equal(0, opts.Scope.Count);

--- a/test/Steeltoe.CloudFoundry.Connector.OAuth.Test/OAuthConnectorFactoryTest.cs
+++ b/test/Steeltoe.CloudFoundry.Connector.OAuth.Test/OAuthConnectorFactoryTest.cs
@@ -24,7 +24,7 @@ namespace Steeltoe.CloudFoundry.Connector.OAuth.Test
         [Fact]
         public void Create_ReturnsOAuthOptions()
         {
-            SsoServiceInfo si = new SsoServiceInfo("myId", "myClientId", "myClientSecret", "http://foo.bar");
+            SsoServiceInfo si = new SsoServiceInfo("myId", "myClientId", "myClientSecret", "https://foo.bar");
             OAuthConnectorOptions config = new OAuthConnectorOptions();
 
             var factory = new OAuthConnectorFactory(si, config);
@@ -35,13 +35,13 @@ namespace Steeltoe.CloudFoundry.Connector.OAuth.Test
             Assert.NotNull(opts);
 
 
-            Assert.Equal("http://foo.bar" + OAuthConnectorDefaults.Default_AccessTokenUri, opts.AccessTokenUrl);
+            Assert.Equal("https://foo.bar" + OAuthConnectorDefaults.Default_AccessTokenUri, opts.AccessTokenUrl);
             Assert.Equal("myClientId", opts.ClientId);
             Assert.Equal("myClientSecret", opts.ClientSecret);
-            Assert.Equal("http://foo.bar" + OAuthConnectorDefaults.Default_JwtTokenKey, opts.JwtKeyUrl);
-            Assert.Equal("http://foo.bar" + OAuthConnectorDefaults.Default_CheckTokenUri, opts.TokenInfoUrl);
-            Assert.Equal("http://foo.bar" + OAuthConnectorDefaults.Default_AuthorizationUri, opts.UserAuthorizationUrl);
-            Assert.Equal("http://foo.bar" + OAuthConnectorDefaults.Default_UserInfoUri, opts.UserInfoUrl);
+            Assert.Equal("https://foo.bar" + OAuthConnectorDefaults.Default_JwtTokenKey, opts.JwtKeyUrl);
+            Assert.Equal("https://foo.bar" + OAuthConnectorDefaults.Default_CheckTokenUri, opts.TokenInfoUrl);
+            Assert.Equal("https://foo.bar" + OAuthConnectorDefaults.Default_AuthorizationUri, opts.UserAuthorizationUrl);
+            Assert.Equal("https://foo.bar" + OAuthConnectorDefaults.Default_UserInfoUri, opts.UserInfoUrl);
             Assert.NotNull(opts.Scope);
             Assert.Equal(0, opts.Scope.Count);
         }

--- a/test/Steeltoe.CloudFoundry.Connector.OAuth.Test/OAuthConnectorOptionsTest.cs
+++ b/test/Steeltoe.CloudFoundry.Connector.OAuth.Test/OAuthConnectorOptionsTest.cs
@@ -43,7 +43,7 @@ namespace Steeltoe.CloudFoundry.Connector.OAuth.Test
    'security': {
         'oauth2': {
             'client': {
-                'oauthServiceUrl': 'http://foo.bar',
+                'oauthServiceUrl': 'https://foo.bar',
                 'clientId': 'clientid',
                 'clientSecret': 'clientsecret',
                 'userAuthorizationUri': 'userauthorizationuri',
@@ -74,7 +74,7 @@ namespace Steeltoe.CloudFoundry.Connector.OAuth.Test
             Assert.Equal("clientid", sconfig.ClientId);
             Assert.Equal("clientsecret", sconfig.ClientSecret);
             Assert.Equal("jwtkeyuri", sconfig.JwtKeyUri);
-            Assert.Equal("http://foo.bar", sconfig.OAuthServiceUrl);
+            Assert.Equal("https://foo.bar", sconfig.OAuthServiceUrl);
             Assert.Equal("tokeninfouri", sconfig.TokenInfoUri);
             Assert.Equal("userauthorizationuri", sconfig.UserAuthorizationUri);
             Assert.Equal("userinfouri", sconfig.UserInfoUri);

--- a/test/Steeltoe.CloudFoundry.Connector.Test/CloudFoundryServiceInfoCreatorTest.cs
+++ b/test/Steeltoe.CloudFoundry.Connector.Test/CloudFoundryServiceInfoCreatorTest.cs
@@ -178,9 +178,9 @@ namespace Steeltoe.CloudFoundry.Connector.Test
                 'username': '03c7a684-6ff1-4bd0-ad45-d10374ffb2af',
                 'port': 15672,
                 'host': '192.168.0.81',
-                'uri': 'http://03c7a684-6ff1-4bd0-ad45-d10374ffb2af:l5oq2q0unl35s6urfsuib0jvpo@192.168.0.81:15672/api/',
+                'uri': 'https://03c7a684-6ff1-4bd0-ad45-d10374ffb2af:l5oq2q0unl35s6urfsuib0jvpo@192.168.0.81:15672/api/',
                 'uris': [
-                  'http://03c7a684-6ff1-4bd0-ad45-d10374ffb2af:l5oq2q0unl35s6urfsuib0jvpo@192.168.0.81:15672/api/'
+                  'https://03c7a684-6ff1-4bd0-ad45-d10374ffb2af:l5oq2q0unl35s6urfsuib0jvpo@192.168.0.81:15672/api/'
                 ]
 },
               'amqp': {

--- a/test/Steeltoe.CloudFoundry.Connector.Test/Services/EurekaServiceInfoFactoryTest.cs
+++ b/test/Steeltoe.CloudFoundry.Connector.Test/Services/EurekaServiceInfoFactoryTest.cs
@@ -34,7 +34,7 @@ namespace Steeltoe.CloudFoundry.Connector.Services.Test
                     { "client_id", new Credential("clientId")},
                     { "client_secret", new Credential("clientSecret")},
                     { "access_token_uri", new Credential("https://p-spring-cloud-services.uaa.my-cf.com/oauth/token")},
-                    { "uri", new Credential("http://username:password@192.168.0.90:1111/") },
+                    { "uri", new Credential("https://username:password@192.168.0.90:1111/") },
                     }
             };
             EurekaServiceInfoFactory factory = new EurekaServiceInfoFactory();
@@ -77,7 +77,7 @@ namespace Steeltoe.CloudFoundry.Connector.Services.Test
                     { "client_id", new Credential("clientId")},
                     { "client_secret", new Credential("clientSecret")},
                     { "access_token_uri", new Credential("https://p-spring-cloud-services.uaa.my-cf.com/oauth/token")},
-                    { "uri", new Credential("http://username:password@192.168.0.90:1111/") },
+                    { "uri", new Credential("https://username:password@192.168.0.90:1111/") },
                     }
             };
             EurekaServiceInfoFactory factory = new EurekaServiceInfoFactory();
@@ -91,7 +91,7 @@ namespace Steeltoe.CloudFoundry.Connector.Services.Test
             Assert.Equal("clientId", info.ClientId);
             Assert.Equal("clientSecret", info.ClientSecret);
             Assert.Equal("https://p-spring-cloud-services.uaa.my-cf.com/oauth/token", info.TokenUri);
-            Assert.Equal("http://username:password@192.168.0.90:1111/", info.Uri);
+            Assert.Equal("https://username:password@192.168.0.90:1111/", info.Uri);
         }
     }
 }

--- a/test/Steeltoe.CloudFoundry.Connector.Test/Services/HystrixRabbitServiceInfoFactoryTest.cs
+++ b/test/Steeltoe.CloudFoundry.Connector.Test/Services/HystrixRabbitServiceInfoFactoryTest.cs
@@ -224,9 +224,9 @@ namespace Steeltoe.CloudFoundry.Connector.Services.Test
             'username': 'a0f39f25-28a2-438e-a0e7-6c09d6d34dbd',
             'port': 15672,
             'host': '192.168.1.55',
-            'uri': 'http://a0f39f25-28a2-438e-a0e7-6c09d6d34dbd:1clgf5ipeop36437dmr2em4duk@192.168.1.55:15672/api/',
+            'uri': 'https://a0f39f25-28a2-438e-a0e7-6c09d6d34dbd:1clgf5ipeop36437dmr2em4duk@192.168.1.55:15672/api/',
             'uris': [
-            'http://a0f39f25-28a2-438e-a0e7-6c09d6d34dbd:1clgf5ipeop36437dmr2em4duk@192.168.1.55:15672/api/'
+            'https://a0f39f25-28a2-438e-a0e7-6c09d6d34dbd:1clgf5ipeop36437dmr2em4duk@192.168.1.55:15672/api/'
             ]
             }
             },

--- a/test/Steeltoe.CloudFoundry.Connector.Test/Services/RabbitServiceInfoFactoryTest.cs
+++ b/test/Steeltoe.CloudFoundry.Connector.Test/Services/RabbitServiceInfoFactoryTest.cs
@@ -194,9 +194,9 @@ namespace Steeltoe.CloudFoundry.Connector.Services.Test
                 'username': '03c7a684-6ff1-4bd0-ad45-d10374ffb2af',
                 'port': 15672,
                 'host': '192.168.0.81',
-                'uri': 'http://03c7a684-6ff1-4bd0-ad45-d10374ffb2af:l5oq2q0unl35s6urfsuib0jvpo@192.168.0.81:15672/api/',
+                'uri': 'https://03c7a684-6ff1-4bd0-ad45-d10374ffb2af:l5oq2q0unl35s6urfsuib0jvpo@192.168.0.81:15672/api/',
                 'uris': [
-                  'http://03c7a684-6ff1-4bd0-ad45-d10374ffb2af:l5oq2q0unl35s6urfsuib0jvpo@192.168.0.81:15672/api/'
+                  'https://03c7a684-6ff1-4bd0-ad45-d10374ffb2af:l5oq2q0unl35s6urfsuib0jvpo@192.168.0.81:15672/api/'
                 ]
               },
               'amqp': {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://network.pivotal.io/open-source (301) with 1 occurrences migrated to:  
  https://network.pivotal.io/open-source ([https](https://network.pivotal.io/open-source) result ReadTimeoutException).
* [ ] http://03c7a684-6ff1-4bd0-ad45-d10374ffb2af:l5oq2q0unl35s6urfsuib0jvpo@192.168.0.81:15672/api/ (UnknownHostException) with 4 occurrences migrated to:  
  https://03c7a684-6ff1-4bd0-ad45-d10374ffb2af:l5oq2q0unl35s6urfsuib0jvpo@192.168.0.81:15672/api/ ([https](https://03c7a684-6ff1-4bd0-ad45-d10374ffb2af:l5oq2q0unl35s6urfsuib0jvpo@192.168.0.81:15672/api/) result UnknownHostException).
* [ ] http://a0f39f25-28a2-438e-a0e7-6c09d6d34dbd:1clgf5ipeop36437dmr2em4duk@192.168.1.55:15672/api/ (UnknownHostException) with 8 occurrences migrated to:  
  https://a0f39f25-28a2-438e-a0e7-6c09d6d34dbd:1clgf5ipeop36437dmr2em4duk@192.168.1.55:15672/api/ ([https](https://a0f39f25-28a2-438e-a0e7-6c09d6d34dbd:1clgf5ipeop36437dmr2em4duk@192.168.1.55:15672/api/) result UnknownHostException).
* [ ] http://foo.bar (UnknownHostException) with 20 occurrences migrated to:  
  https://foo.bar ([https](https://foo.bar) result UnknownHostException).
* [ ] http://username:password@192.168.0.90:1111/ (UnknownHostException) with 3 occurrences migrated to:  
  https://username:password@192.168.0.90:1111/ ([https](https://username:password@192.168.0.90:1111/) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://redis.io/ with 1 occurrences migrated to:  
  https://redis.io/ ([https](https://redis.io/) result 200).
* [ ] http://redis.io/documentation with 1 occurrences migrated to:  
  https://redis.io/documentation ([https](https://redis.io/documentation) result 200).
* [ ] http://redis.io/topics/license with 1 occurrences migrated to:  
  https://redis.io/topics/license ([https](https://redis.io/topics/license) result 200).
* [ ] http://steeltoe.io with 7 occurrences migrated to:  
  https://steeltoe.io ([https](https://steeltoe.io) result 200).
* [ ] http://steeltoe.io/ with 7 occurrences migrated to:  
  https://steeltoe.io/ ([https](https://steeltoe.io/) result 200).
* [ ] http://steeltoe.io/images/transparent.png with 7 occurrences migrated to:  
  https://steeltoe.io/images/transparent.png ([https](https://steeltoe.io/images/transparent.png) result 200).
* [ ] http://www.npgsql.org/ with 1 occurrences migrated to:  
  https://www.npgsql.org/ ([https](https://www.npgsql.org/) result 200).
* [ ] http://aspnetwebstack.codeplex.com/wikipage?title=Contributors with 1 occurrences migrated to:  
  https://aspnetwebstack.codeplex.com/wikipage?title=Contributors ([https](https://aspnetwebstack.codeplex.com/wikipage?title=Contributors) result 301).

# Ignored
These URLs were intentionally ignored.

* http://bar:11 with 3 occurrences
* http://boo:222 with 4 occurrences
* http://foo:11 with 3 occurrences
* http://username:password@hostname:1111/ with 2 occurrences